### PR TITLE
Implement Ceres Plugins

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.0" />
+    <option name="version" value="1.9.10" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ The `drifter-wallpaper` module focuses on wallpaper-related features and tools f
 
 The `drifter-plugin` module provides a Gradle plugin that can be used to enhance your Android project build process. It offers features such as code generation, resource management, and more.
 
+This Gradle plugin simplifies Unity integration for your project by providing two essential tasks:
+
+1. **BuildIl2CppTask**: Compiles and builds Il2Cpp for Unity integration.
+2. **UnityAssetSyncTask**: Synchronizes Unity exported assets for project preparation.
+
 [Explore the source code](/drifter-plugin)
 
 ## Find this repository useful? :heart:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-  alias(libs.plugins.androidApplication)
-  alias(libs.plugins.kotlinAndroid)
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.jetbrains.kotlin.android)
 }
 
 android {
@@ -24,7 +24,7 @@ android {
 
   defaultConfig {
     applicationId = "dev.teogor.drifter.demo"
-    minSdk = 24
+    minSdk = 21
     targetSdk = 34
     versionCode = 1
     versionName = "1.0.0-alpha01"
@@ -56,7 +56,7 @@ android {
     compose = true
   }
   composeOptions {
-    kotlinCompilerExtensionVersion = "1.5.1"
+    kotlinCompilerExtensionVersion = "1.5.3"
   }
   packaging {
     resources {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 plugins {
-  alias(libs.plugins.android.application)
-  alias(libs.plugins.jetbrains.kotlin.android)
+  alias(libs.plugins.ceres.android.application)
+  alias(libs.plugins.ceres.android.application.compose)
 }
 
 android {
   namespace = "dev.teogor.drifter.demo"
-  compileSdk = 34
 
   defaultConfig {
     applicationId = "dev.teogor.drifter.demo"
-    minSdk = 21
-    targetSdk = 34
     versionCode = 1
     versionName = "1.0.0-alpha01"
 
@@ -45,19 +42,7 @@ android {
       signingConfig = signingConfigs.getByName("debug")
     }
   }
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-  }
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
-  }
-  buildFeatures {
-    compose = true
-  }
-  composeOptions {
-    kotlinCompilerExtensionVersion = "1.5.3"
-  }
+
   packaging {
     resources {
       excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
-  alias(libs.plugins.androidApplication) apply false
-  alias(libs.plugins.androidLibrary) apply false
-  alias(libs.plugins.kotlinAndroid) apply false
+  alias(libs.plugins.android.application) apply false
+  alias(libs.plugins.android.library) apply false
+  alias(libs.plugins.jetbrains.kotlin.android) apply false
   alias(libs.plugins.vanniktech.maven) apply false
   id("dev.teogor.publish") apply false
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,11 @@ plugins {
   alias(libs.plugins.vanniktech.maven) apply false
   id("dev.teogor.publish") apply false
 
+  alias(libs.plugins.ceres.android.application) apply false
+  alias(libs.plugins.ceres.android.application.compose) apply false
+  alias(libs.plugins.ceres.android.library) apply false
+  alias(libs.plugins.ceres.android.library.compose) apply false
+
   alias(libs.plugins.dokka)
   alias(libs.plugins.spotless)
   alias(libs.plugins.apiValidator)

--- a/docs/drifter-plugin.md
+++ b/docs/drifter-plugin.md
@@ -1,0 +1,124 @@
+# Usage Guide for Drifter-Plugin (Unity Integration Plugin)
+
+## Overview
+
+The Unity Integration Plugin simplifies the process of integrating Unity projects into your Gradle-based project. It provides two essential tasks: `BuildIl2CppTask` and `UnityAssetSyncTask`. This guide explains how to use these tasks effectively.
+
+## Prerequisites
+
+Before using the Unity Integration Plugin, ensure the following:
+
+- You have a Gradle-based Android project.
+- Unity projects to be integrated have been properly exported.
+
+## Installation
+
+To get started, add the Unity Integration Plugin to your `build.gradle` file:
+
+```groovy
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'your.plugin.dependency.here'
+    }
+}
+
+apply plugin: 'dev.teogor.drifter.plugin'
+```
+
+## Using `BuildIl2CppTask`
+
+### Purpose
+
+The `BuildIl2CppTask` automates the compilation and building of Il2Cpp for Unity integration. It enhances the efficiency of your development workflow by handling complex build processes.
+
+### Configuration
+
+To use `BuildIl2CppTask`, follow these steps:
+
+1. Configure Unity options in your `build.gradle` file.
+
+```groovy
+unityOptions {
+    exportFolder = 'path/to/unity/export/folder'
+    libraryName = 'YourUnityLibrary'
+    // Add more configuration options as needed
+}
+```
+
+2. Create the task and set Unity options:
+
+```groovy
+createBuildIl2CppTask(unityOptions)
+```
+
+3. Execute the task:
+
+```shell
+./gradlew buildIl2Cpp
+```
+
+Here's a Kotlin code snippet for your `build.gradle` file that demonstrates the configuration and usage:
+
+```kotlin
+// Configure Unity options
+unityOptions {
+    exportFolder = 'path/to/unity/export/folder'
+    libraryName = 'YourUnityLibrary'
+    // Add more configuration options as needed
+}
+
+// Create and set up the BuildIl2CppTask
+createBuildIl2CppTask(unityOptions)
+
+// Execute the BuildIl2CppTask
+project.tasks.named("buildIl2Cpp").configure {
+    // Add any additional configuration or dependencies here if needed
+    // For example:
+    // dependsOn("someOtherTask")
+}
+```
+
+## Using `UnityAssetSyncTask`
+
+### Purpose
+
+The `UnityAssetSyncTask` streamlines the synchronization of Unity exported assets with your project. It prepares the project for Unity integration by copying essential folders.
+
+### Configuration
+
+To use `UnityAssetSyncTask`, follow these steps:
+
+1. Configure Unity options in your `build.gradle` file (if not already done).
+
+2. Create the task and set Unity options:
+
+```groovy
+createUnityAssetSyncTask(unityOptions)
+```
+
+3. Execute the task:
+
+```shell
+./gradlew syncUnityAssets
+```
+
+Here's a Kotlin code snippet for your `build.gradle` file that demonstrates the configuration and usage:
+
+```kotlin
+// Create and set up the UnityAssetSyncTask
+createUnityAssetSyncTask(unityOptions)
+
+// Execute the UnityAssetSyncTask
+project.tasks.named("syncUnityAssets").configure {
+    // Add any additional configuration or dependencies here if needed
+    // For example:
+    // dependsOn("anotherTask")
+}
+```
+
+## Conclusion
+
+With the Unity Integration Plugin, you can seamlessly integrate Unity projects into your Gradle-based project, enhancing the development process and ensuring consistency. If you encounter any issues or have feature requests, please don't hesitate to contribute or reach out for support.

--- a/drifter-bom/build.gradle.kts
+++ b/drifter-bom/build.gradle.kts
@@ -18,40 +18,40 @@ import dev.teogor.publish.applyPublishOptions
 
 plugins {
   id("java-platform")
-
   id("dev.teogor.publish")
 }
 
-publishOptions {
+afterEvaluate {
+  publishOptions {
 
-  defaultLibraryInfo(
-    artifactId = "bom",
-    version = "1.0.0-alpha01",
-  )
-
-  configureBomModule {
-    acceptedModules = listOf(
-      "drifter-compose",
-      "drifter-core",
-      "drifter-integration",
-      "drifter-wallpaper",
+    defaultLibraryInfo(
+      artifactId = "bom",
+      version = "1.0.0-alpha01",
     )
-  }
 
-  mavenPublishing {
-    publishToMavenCentral(SonatypeHost.S01)
-    signAllPublications()
-
-    @Suppress("UnstableApiUsage")
-    pom {
-      coordinates(
-        groupId = this@publishOptions.groupId,
-        artifactId = this@publishOptions.artifactId,
-        version = this@publishOptions.version,
+    configureBomModule {
+      acceptedModules = listOf(
+        "drifter-compose",
+        "drifter-core",
+        "drifter-integration",
+        "drifter-wallpaper",
       )
+    }
 
-      applyPublishOptions(this@publishOptions)
+    mavenPublishing {
+      publishToMavenCentral(SonatypeHost.S01)
+      signAllPublications()
+
+      @Suppress("UnstableApiUsage")
+      pom {
+        coordinates(
+          groupId = this@publishOptions.groupId,
+          artifactId = this@publishOptions.artifactId,
+          version = this@publishOptions.version,
+        )
+
+        applyPublishOptions(this@publishOptions)
+      }
     }
   }
-
 }

--- a/drifter-compose/build.gradle.kts
+++ b/drifter-compose/build.gradle.kts
@@ -17,8 +17,8 @@ import com.vanniktech.maven.publish.SonatypeHost
 import dev.teogor.publish.applyPublishOptions
 
 plugins {
-  alias(libs.plugins.androidLibrary)
-  alias(libs.plugins.kotlinAndroid)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.jetbrains.kotlin.android)
 
   id("dev.teogor.publish")
 }
@@ -28,7 +28,7 @@ android {
   compileSdk = 34
 
   defaultConfig {
-    minSdk = 24
+    minSdk = 21
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles("consumer-rules.pro")
@@ -58,7 +58,7 @@ android {
   }
 
   composeOptions {
-    kotlinCompilerExtensionVersion = "1.5.1"
+    kotlinCompilerExtensionVersion = "1.5.3"
   }
 }
 

--- a/drifter-compose/build.gradle.kts
+++ b/drifter-compose/build.gradle.kts
@@ -17,18 +17,16 @@ import com.vanniktech.maven.publish.SonatypeHost
 import dev.teogor.publish.applyPublishOptions
 
 plugins {
-  alias(libs.plugins.android.library)
-  alias(libs.plugins.jetbrains.kotlin.android)
+  alias(libs.plugins.ceres.android.library)
+  alias(libs.plugins.ceres.android.library.compose)
 
   id("dev.teogor.publish")
 }
 
 android {
   namespace = "dev.teogor.drifter.compose"
-  compileSdk = 34
 
   defaultConfig {
-    minSdk = 21
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles("consumer-rules.pro")
@@ -42,23 +40,6 @@ android {
         "proguard-rules.pro",
       )
     }
-  }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-  }
-
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
-  }
-
-  buildFeatures {
-    compose = true
-  }
-
-  composeOptions {
-    kotlinCompilerExtensionVersion = "1.5.3"
   }
 }
 

--- a/drifter-core/build.gradle.kts
+++ b/drifter-core/build.gradle.kts
@@ -17,8 +17,8 @@ import com.vanniktech.maven.publish.SonatypeHost
 import dev.teogor.publish.applyPublishOptions
 
 plugins {
-  alias(libs.plugins.androidLibrary)
-  alias(libs.plugins.kotlinAndroid)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.jetbrains.kotlin.android)
 
   id("dev.teogor.publish")
 }
@@ -28,7 +28,7 @@ android {
   compileSdk = 34
 
   defaultConfig {
-    minSdk = 24
+    minSdk = 21
 
     consumerProguardFiles("proguard-unity.txt")
   }

--- a/drifter-core/build.gradle.kts
+++ b/drifter-core/build.gradle.kts
@@ -17,19 +17,15 @@ import com.vanniktech.maven.publish.SonatypeHost
 import dev.teogor.publish.applyPublishOptions
 
 plugins {
-  alias(libs.plugins.android.library)
-  alias(libs.plugins.jetbrains.kotlin.android)
+  alias(libs.plugins.ceres.android.library)
 
   id("dev.teogor.publish")
 }
 
 android {
   namespace = "dev.teogor.drifter.core"
-  compileSdk = 34
 
   defaultConfig {
-    minSdk = 21
-
     consumerProguardFiles("proguard-unity.txt")
   }
 
@@ -41,15 +37,6 @@ android {
         "proguard-rules.pro",
       )
     }
-  }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-  }
-
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
   }
 }
 

--- a/drifter-integration/build.gradle.kts
+++ b/drifter-integration/build.gradle.kts
@@ -17,8 +17,8 @@ import com.vanniktech.maven.publish.SonatypeHost
 import dev.teogor.publish.applyPublishOptions
 
 plugins {
-  alias(libs.plugins.androidLibrary)
-  alias(libs.plugins.kotlinAndroid)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.jetbrains.kotlin.android)
 
   id("dev.teogor.publish")
 }
@@ -28,7 +28,7 @@ android {
   compileSdk = 34
 
   defaultConfig {
-    minSdk = 24
+    minSdk = 21
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles("consumer-rules.pro")

--- a/drifter-integration/build.gradle.kts
+++ b/drifter-integration/build.gradle.kts
@@ -17,19 +17,15 @@ import com.vanniktech.maven.publish.SonatypeHost
 import dev.teogor.publish.applyPublishOptions
 
 plugins {
-  alias(libs.plugins.android.library)
-  alias(libs.plugins.jetbrains.kotlin.android)
+  alias(libs.plugins.ceres.android.library)
 
   id("dev.teogor.publish")
 }
 
 android {
   namespace = "dev.teogor.drifter.integration"
-  compileSdk = 34
 
   defaultConfig {
-    minSdk = 21
-
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles("consumer-rules.pro")
   }
@@ -42,15 +38,6 @@ android {
         "proguard-rules.pro",
       )
     }
-  }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-  }
-
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
   }
 
   buildFeatures {

--- a/drifter-plugin/build.gradle.kts
+++ b/drifter-plugin/build.gradle.kts
@@ -55,7 +55,7 @@ gradlePlugin {
       id = "dev.teogor.drifter.plugin"
       implementationClass = "dev.teogor.drifter.plugin.DrifterPlugin"
       displayName = "Gradle Unity Configurator for Drifter Plugin"
-      description = "Bridging the Gap between Unity and Android Development for Effortless Integration and Performance Enhancement."
+      description = "Drifter simplifies the integration between Unity and Android, enhancing performance seamlessly and effortlessly."
       tags.set(listOf("drifter", "unity", "android", "integration", "performance", "development", "android-library"))
     }
   }

--- a/drifter-wallpaper/build.gradle.kts
+++ b/drifter-wallpaper/build.gradle.kts
@@ -17,19 +17,15 @@ import com.vanniktech.maven.publish.SonatypeHost
 import dev.teogor.publish.applyPublishOptions
 
 plugins {
-  alias(libs.plugins.android.library)
-  alias(libs.plugins.jetbrains.kotlin.android)
+  alias(libs.plugins.ceres.android.library)
 
   id("dev.teogor.publish")
 }
 
 android {
   namespace = "dev.teogor.drifter.wallpaper"
-  compileSdk = 34
 
   defaultConfig {
-    minSdk = 21
-
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles("consumer-rules.pro")
   }
@@ -42,15 +38,6 @@ android {
         "proguard-rules.pro",
       )
     }
-  }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-  }
-
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
   }
 
   buildFeatures {

--- a/drifter-wallpaper/build.gradle.kts
+++ b/drifter-wallpaper/build.gradle.kts
@@ -17,8 +17,8 @@ import com.vanniktech.maven.publish.SonatypeHost
 import dev.teogor.publish.applyPublishOptions
 
 plugins {
-  alias(libs.plugins.androidLibrary)
-  alias(libs.plugins.kotlinAndroid)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.jetbrains.kotlin.android)
 
   id("dev.teogor.publish")
 }
@@ -28,7 +28,7 @@ android {
   compileSdk = 34
 
   defaultConfig {
-    minSdk = 24
+    minSdk = 21
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles("consumer-rules.pro")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,14 @@
-# Project-wide Gradle settings.
+# Project-wide Gradle menu.
 # IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
+# Gradle menu configured through the IDE *will override*
+# any menu specified in this file.
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# The setting is particularly useful for tweaking memory menu.
+# Ensure important default jvmargs aren't overwritten. See https://github.com/gradle/gradle/issues/19750
+org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=4g
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+# When enabled, advanced flavours are added, affecting the CeresFlavor enum.
+ceres.buildfeatures.flavours=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,37 @@
 [versions]
+# @todo-ceres required by id::ceres.android.{application/library}
+androidDesugarJdkLibs = "2.0.3"
+
+# @todo-ceres required by id::ceres.android.application.compose
+androidxComposeCompiler = "1.5.3"
+androidxComposeBom = "2023.09.01"
+
+# @todo-ceres required by id::ceres.android.application.firebase
+firebaseBom = "32.3.1"
+firebaseCrashlyticsPlugin = "2.9.9"
+firebasePerfPlugin = "1.4.2"
+
+# @todo-ceres required by id::ceres.android.library
+junit4 = "4.13.2"
+
+# @todo-ceres required by id::ceres.android.hilt
+hilt = "2.47"
+hiltExt = "1.0.0"
+
+# @todo-ceres required by ceres.*
+ceres-bom = "1.0.0-alpha01"
+ceres-plugin = "1.0.0-alpha01"
+
+# @todo-ceres required by id::ceres.*
+androidGradlePlugin = "8.2.0-beta06"
+gmsPlugin = "4.4.0"
+protobufPlugin = "0.9.4"
+
 apiValidator = "0.13.2"
 agp = "8.2.0-beta06"
 annotation = "1.7.0"
 buildConfig = "3.1.0"
-kotlin = "1.9.0"
+kotlin = "1.9.10"
 core-ktx = "1.12.0"
 junit = "4.13.2"
 androidx-test-ext-junit = "1.1.5"
@@ -17,10 +45,44 @@ material = "1.9.0"
 startup-runtime = "1.2.0-alpha02"
 gson = "2.10.1"
 vanniktechMavenPlugin = "0.25.3"
-dokka = "1.8.20"
-spotless = "6.20.0"
+dokka = "1.9.0"
+spotless = "6.21.0"
 
 [libraries]
+# @todo-ceres required by id::ceres.android.application
+android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }
+
+# @todo-ceres required by id::ceres.android.application.compose
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
+
+# @todo-ceres required by id::ceres.android.application.firebase
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics-ktx" }
+firebase-crashlytics-gradle = { group = "com.google.firebase", name = "firebase-crashlytics-gradle", version.ref = "firebaseCrashlyticsPlugin" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics-ktx" }
+firebase-performance-gradle = { group = "com.google.firebase", name = "perf-plugin", version.ref = "firebasePerfPlugin" }
+firebase-performance = { group = "com.google.firebase", name = "firebase-perf-ktx" }
+
+# @todo-ceres required by id::ceres.android.library
+junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
+
+# @todo-ceres required by id::ceres.android.hilt
+hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
+hilt-ext-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltExt" }
+hilt-ext-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltExt" }
+
+# @todo-ceres required by ceres
+ceres-bom = { group = "dev.teogor.ceres", name = "bom", version.ref = "ceres-bom" }
+ceres-framework-core = { group = "dev.teogor.ceres", name = "framework-core" }
+ceres-screen-builder = { group = "dev.teogor.ceres", name = "screen-builder" }
+ceres-screen-core = { group = "dev.teogor.ceres", name = "screen-core" }
+ceres-screen-ui = { group = "dev.teogor.ceres", name = "screen-ui" }
+ceres-ui-theme = { group = "dev.teogor.ceres", name = "ui-theme" }
+ceres-monetisation-admob = { group = "dev.teogor.ceres", name = "monetisation-admob" }
+ceres-monetisation-messaging = { group = "dev.teogor.ceres", name = "monetisation-messaging" }
+
 buildconfig-plugin = { module = "com.github.gmazzo:gradle-buildconfig-pluginn", version.ref = "buildConfig" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 androidx-startup-runtime = { module = "androidx.startup:startup-runtime", version.ref = "startup-runtime" }
@@ -48,11 +110,37 @@ ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devto
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 
 [plugins]
-androidApplication = { id = "com.android.application", version.ref = "agp" }
-androidLibrary = { id = "com.android.library", version.ref = "agp" }
-kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 vanniktech-maven = { id = "com.vanniktech.maven.publish", version.ref = "vanniktechMavenPlugin" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildConfig" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 apiValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "apiValidator" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+
+# @todo-ceres required by id::ceres.*
+ceres-android-application = { id = "dev.teogor.ceres.android.application", version.ref = "ceres-plugin" }
+ceres-android-application-compose = { id = "dev.teogor.ceres.android.application.compose", version.ref = "ceres-plugin" }
+ceres-android-application-firebase = { id = "dev.teogor.ceres.android.application.firebase", version.ref = "ceres-plugin" }
+ceres-android-application-flavors = { id = "dev.teogor.ceres.android.application.flavors", version.ref = "ceres-plugin" }
+ceres-android-application-jacoco = { id = "dev.teogor.ceres.android.application.jacoco", version.ref = "ceres-plugin" }
+ceres-android-feature = { id = "dev.teogor.ceres.android.feature", version.ref = "ceres-plugin" }
+ceres-android-hilt = { id = "dev.teogor.ceres.android.hilt", version.ref = "ceres-plugin" }
+ceres-android-library = { id = "dev.teogor.ceres.android.library", version.ref = "ceres-plugin" }
+ceres-android-library-compose = { id = "dev.teogor.ceres.android.library.compose", version.ref = "ceres-plugin" }
+ceres-android-library-config = { id = "dev.teogor.ceres.android.library.config", version.ref = "ceres-plugin" }
+ceres-android-room = { id = "dev.teogor.ceres.android.room", version.ref = "ceres-plugin" }
+ceres-android-test = { id = "dev.teogor.ceres.android.test", version.ref = "ceres-plugin" }
+ceres-docs = { id = "dev.teogor.ceres.docs", version.ref = "ceres-plugin" }
+
+# @todo-ceres required by id::ceres.*
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+android-test = { id = "com.android.test", version.ref = "androidGradlePlugin" }
+jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }
+firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerfPlugin" }
+gms = { id = "com.google.gms.google-services", version.ref = "gmsPlugin" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,6 @@ gmsPlugin = "4.4.0"
 protobufPlugin = "0.9.4"
 
 apiValidator = "0.13.2"
-agp = "8.2.0-beta06"
 annotation = "1.7.0"
 buildConfig = "3.1.0"
 kotlin = "1.9.10"
@@ -104,7 +103,7 @@ appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "a
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 # Dependencies of the included build-logic
-android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
+android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 apiValidator = "0.13.2"
-agp = "8.2.0-beta05"
+agp = "8.2.0-beta06"
 annotation = "1.7.0"
 buildConfig = "3.1.0"
 kotlin = "1.9.0"

--- a/module-unity/build.gradle.kts
+++ b/module-unity/build.gradle.kts
@@ -18,8 +18,7 @@ import dev.teogor.drifter.plugin.models.PlatformArch
 import dev.teogor.drifter.plugin.unityOptions
 
 plugins {
-  alias(libs.plugins.android.library)
-  alias(libs.plugins.jetbrains.kotlin.android)
+  alias(libs.plugins.ceres.android.library)
 
   id("dev.teogor.drifter.plugin")
 }
@@ -29,21 +28,6 @@ val unityStreamingAssetsList: List<String> = unityStreamingAssets?.split(",") ?:
 
 android {
   namespace = "dev.teogor.drifter.demo.unity.library"
-
-  compileSdk = 34
-
-  defaultConfig {
-    minSdk = 21
-  }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-  }
-
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
-  }
 
   unityOptions(
     androidConfig = this,

--- a/module-unity/build.gradle.kts
+++ b/module-unity/build.gradle.kts
@@ -18,8 +18,8 @@ import dev.teogor.drifter.plugin.models.PlatformArch
 import dev.teogor.drifter.plugin.unityOptions
 
 plugins {
-  alias(libs.plugins.androidLibrary)
-  alias(libs.plugins.kotlinAndroid)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.jetbrains.kotlin.android)
 
   id("dev.teogor.drifter.plugin")
 }
@@ -33,7 +33,7 @@ android {
   compileSdk = 34
 
   defaultConfig {
-    minSdk = 24
+    minSdk = 21
   }
 
   compileOptions {


### PR DESCRIPTION
This pull request adds the implementation of Ceres Plugins as per the requirements outlined in `@todo-ceres`. The following Ceres Plugins have been implemented:

- `ceres-android-application`
- `ceres-android-application-compose`
- `ceres-android-application-firebase`
- `ceres-android-application-flavors`
- `ceres-android-application-jacoco`
- `ceres-android-feature`
- `ceres-android-hilt`
- `ceres-android-library`
- `ceres-android-library-compose`
- `ceres-android-library-config`
- `ceres-android-room`
- `ceres-android-test`
- `ceres-docs`

These plugins are now available for use, and they are configured to reference the `ceres-plugin` version.

closes #5 