### PR TITLE
Fix configuration issue with mergeVariantJniLibFolders task

### DIFF
--- a/drifter-plugin/src/main/kotlin/dev/teogor/drifter/plugin/UnityBuildTask.kt
+++ b/drifter-plugin/src/main/kotlin/dev/teogor/drifter/plugin/UnityBuildTask.kt
@@ -48,11 +48,11 @@ fun Project.unityBuildTask(
     }
 
     afterEvaluate {
-      if (project(path).tasks.named("mergeDebugJniLibFolders").getOrNull() != null) {
+      if (project(path).tasks.findByName("mergeDebugJniLibFolders") != null) {
         project(path).tasks.named("mergeDebugJniLibFolders").get()
           .dependsOn(buildIl2CppTask)
       }
-      if (project(path).tasks.named("mergeReleaseJniLibFolders").getOrNull() != null) {
+      if (project(path).tasks.findByName("mergeReleaseJniLibFolders") != null) {
         project(path).tasks.named("mergeReleaseJniLibFolders").get()
           .dependsOn(buildIl2CppTask)
       }


### PR DESCRIPTION
## Fix Configuration Issue with mergeVariantJniLibFolders Task

This pull request addresses a configuration issue in the Drifter plugin where the `mergeVariantJniLibFolders` task was not found in certain project configurations.

**Changes:**

- Enhanced the task dependency check logic in the Drifter plugin to gracefully handle cases where the `mergeVariantJniLibFolders` task might not exist in a project.
- Replaced `getOrNull()` with `findByName()` to more reliably locate the task if it's present.

**Benefits:**

- Prevents configuration errors related to missing `mergeVariantJniLibFolders` tasks.
- Improves compatibility with different project setups.
- Ensures smoother integration of the Drifter plugin in various scenarios.