### PR TITLE
Enhance PlatformArch with common architectures via companion object

### DIFF
--- a/drifter-plugin/api/drifter-plugin.api
+++ b/drifter-plugin/api/drifter-plugin.api
@@ -61,6 +61,7 @@ public final class dev/teogor/drifter/plugin/models/Configuration : java/lang/En
 }
 
 public final class dev/teogor/drifter/plugin/models/PlatformArch {
+	public static final field Companion Ldev/teogor/drifter/plugin/models/PlatformArch$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
@@ -71,6 +72,13 @@ public final class dev/teogor/drifter/plugin/models/PlatformArch {
 	public final fun getArchitecture ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/drifter/plugin/models/PlatformArch$Companion {
+	public final fun getArm64 ()Ldev/teogor/drifter/plugin/models/PlatformArch;
+	public final fun getArmv7 ()Ldev/teogor/drifter/plugin/models/PlatformArch;
+	public final fun getChromeOs ()Ldev/teogor/drifter/plugin/models/PlatformArch;
+	public final fun getWebXR ()Ldev/teogor/drifter/plugin/models/PlatformArch;
 }
 
 public final class dev/teogor/drifter/plugin/models/UnityOptions {

--- a/drifter-plugin/src/main/kotlin/dev/teogor/drifter/plugin/models/PlatformArch.kt
+++ b/drifter-plugin/src/main/kotlin/dev/teogor/drifter/plugin/models/PlatformArch.kt
@@ -26,4 +26,23 @@ package dev.teogor.drifter.plugin.models
 data class PlatformArch(
   val abi: String,
   val architecture: String,
-)
+) {
+  companion object {
+    val Armv7 = PlatformArch(
+      abi = "armeabi-v7a",
+      architecture = "armv7",
+    )
+    val Arm64 = PlatformArch(
+      abi = "arm64-v8a",
+      architecture = "arm64",
+    )
+    val ChromeOs = PlatformArch(
+      abi = "x86",
+      architecture = "x86",
+    )
+    val WebXR = PlatformArch(
+      abi = "x86_64",
+      architecture = "x86_64",
+    )
+  }
+}


### PR DESCRIPTION
## Enhance PlatformArch with Common Architectures via Companion Object

This pull request introduces a companion object to the `PlatformArch` data class, offering convenient access to common platform architectures:

**Changes:**

* Added a companion object to `PlatformArch`.
* Defined constants for frequently used architectures (Armv7, Arm64, ChromeOs, WebXR).
* Each constant provides `abi` and `architecture` values for clarity.

**Benefits:**

* Simplifies usage of common platform architectures in code.
* Improves code readability and maintainability.
* Reduces the need for manually specifying these values.

**Example Usage:**

```kotlin
val platformArch = PlatformArch.Arm64 // Access predefined constant
```
