### PR TITLE
Introduce safe property access for Unity NDK and export paths

### DIFF
--- a/drifter-plugin/api/drifter-plugin.api
+++ b/drifter-plugin/api/drifter-plugin.api
@@ -25,6 +25,16 @@ public final class dev/teogor/drifter/plugin/DrifterPlugin : org/gradle/api/Plug
 	public fun apply (Lorg/gradle/api/Project;)V
 }
 
+public final class dev/teogor/drifter/plugin/DrifterPropertiesKt {
+	public static final fun getDrifterUnityPathExport (Lorg/gradle/api/Project;)Ljava/lang/String;
+	public static final fun getDrifterUnityPathNdk (Lorg/gradle/api/Project;)Ljava/lang/String;
+	public static final fun getSafeDrifterUnityPathExport (Lorg/gradle/api/Project;)Ljava/lang/String;
+	public static final fun getSafeDrifterUnityPathNdk (Lorg/gradle/api/Project;)Ljava/lang/String;
+}
+
+public abstract interface annotation class dev/teogor/drifter/plugin/InternalDrifterApi : java/lang/annotation/Annotation {
+}
+
 public class dev/teogor/drifter/plugin/UnityAssetSyncTask : org/gradle/api/DefaultTask {
 	public fun <init> ()V
 	public final fun importContent ()V

--- a/drifter-plugin/src/main/kotlin/dev/teogor/drifter/plugin/DrifterProperties.kt
+++ b/drifter-plugin/src/main/kotlin/dev/teogor/drifter/plugin/DrifterProperties.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(InternalDrifterApi::class)
+
+package dev.teogor.drifter.plugin
+
+import org.gradle.api.Project
+
+/**
+ * Retrieves a property from gradle.properties and converts it to the specified type.
+ *
+ * @param key The property key to retrieve.
+ * @param defaultValue The default value to return if the property is not found or has
+ * an incompatible type.
+ * @throws IllegalArgumentException if the property is not found or has an incompatible
+ * type.
+ */
+inline fun <reified T> Project.getProperty(key: String, defaultValue: T? = null): T? {
+  val value = findProperty(key)?.toString()
+  return when {
+    value != null && T::class.java.isAssignableFrom(value.javaClass) -> value as T
+    defaultValue != null -> defaultValue
+    else -> throw IllegalArgumentException("Property '$key' not found or has incompatible type")
+  }
+}
+
+/**
+ * Getter for the `drifter.unity.path.ndk` property from Gradle properties.
+ */
+@InternalDrifterApi
+val Project.drifterUnityPathNdk: String?
+  get() = getProperty("drifter.unity.path.ndk")
+
+/**
+ * Retrieves the Drifter Unity NDK path from Gradle properties.
+ *
+ * @return The Drifter Unity NDK path.
+ */
+@OptIn(InternalDrifterApi::class)
+fun Project.getSafeDrifterUnityPathNdk(): String {
+  return drifterUnityPathNdk ?: error(
+    "Please provide the required property 'drifter.unity.path.ndk' in gradle.properties",
+  )
+}
+
+/**
+ * Getter for the `drifter.unity.path.export` property from Gradle properties.
+ */
+@InternalDrifterApi
+val Project.drifterUnityPathExport: String?
+  get() = getProperty("drifter.unity.path.export")
+
+/**
+ * Retrieves the Drifter Unity export path from Gradle properties.
+ *
+ * @return The Drifter Unity export path.
+ */
+@OptIn(InternalDrifterApi::class)
+fun Project.getSafeDrifterUnityPathExport(): String {
+  return drifterUnityPathExport ?: error(
+    "Please provide the required property 'drifter.unity.path.export' in gradle.properties",
+  )
+}

--- a/drifter-plugin/src/main/kotlin/dev/teogor/drifter/plugin/InternalDrifterApi.kt
+++ b/drifter-plugin/src/main/kotlin/dev/teogor/drifter/plugin/InternalDrifterApi.kt
@@ -13,25 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-pluginManagement {
-  repositories {
-    google()
-    mavenCentral()
-    gradlePluginPortal()
-  }
-}
 
-@Suppress("UnstableApiUsage")
-dependencyResolutionManagement {
-  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-  repositories {
-    google()
-    mavenCentral()
-  }
+package dev.teogor.drifter.plugin
 
-  versionCatalogs {
-    create("libs") {
-      from(files("${rootDir.parentFile}/gradle/libs.versions.toml"))
-    }
-  }
-}
+@RequiresOptIn(message = "This API is internal to Drifter plugin. Do NOT use it!")
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+annotation class InternalDrifterApi

--- a/module-unity/build.gradle.kts
+++ b/module-unity/build.gradle.kts
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import dev.teogor.drifter.plugin.getSafeDrifterUnityPathExport
+import dev.teogor.drifter.plugin.getSafeDrifterUnityPathNdk
 import dev.teogor.drifter.plugin.models.Configuration
 import dev.teogor.drifter.plugin.models.PlatformArch
 import dev.teogor.drifter.plugin.unityOptions
@@ -39,7 +42,7 @@ android {
     version = "2022.3.7f1"
 
     ndkVersion = "23.1.7779620"
-    ndkPath = "D:\\Unity\\Editor\\2022.3.7f1\\Editor\\Data\\PlaybackEngines\\AndroidPlayer\\NDK"
+    ndkPath = getSafeDrifterUnityPathNdk()
 
     platforms = listOf(
       PlatformArch("armeabi-v7a", "armv7"),
@@ -48,7 +51,7 @@ android {
     configuration = Configuration.Release
     streamingAssets += unityStreamingAssetsList
 
-    exportFolder = "E:\\ZeoOwl\\dev\\.github\\aquarium-unity\\Export"
+    exportFolder = getSafeDrifterUnityPathExport()
   }
 }
 

--- a/module-unity/gradle.properties
+++ b/module-unity/gradle.properties
@@ -1,0 +1,2 @@
+drifter.unity.path.export=E\:\\ZeoOwl\\dev\\.github\\aquarium-unity\\Export
+drifter.unity.path.ndk=D\:\\Unity\\Editor\\2022.3.7f1\\Editor\\Data\\PlaybackEngines\\AndroidPlayer\\NDK


### PR DESCRIPTION
**Summary:**

This PR adds an internal API (`@InternalDrifterApi`) to provide safer and more flexible access to Drifter properties from Gradle build scripts. It introduces the `getSafeDrifterUnityPathNdk()` and `getSafeDrifterUnityPathExport()` functions to ensure required properties are present and handle errors gracefully.

**Motivation:**

- Prevent potential crashes due to missing properties.
- Improve error handling and provide informative messages.
- Allow for future changes to property handling without breaking external code.

**Usage:**

```kotlin
android {
  unityOptions(
    ndkPath = getSafeDrifterUnityPathNdk()
    exportFolder = getSafeDrifterUnityPathExport()
  )
}
```