### PR TITLE
Refactor UnityAssetSyncTask to RefreshUnityAssetsTask with Updated Naming and Documentation

### DIFF
--- a/docs/plugin-usage-guide.md
+++ b/docs/plugin-usage-guide.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-The Unity Integration Plugin simplifies the process of integrating Unity projects into your Gradle-based project. It provides two essential tasks: `BuildIl2CppTask` and `UnityAssetSyncTask`. This guide explains how to use these tasks effectively.
+The Unity Integration Plugin simplifies the process of integrating Unity projects into your
+Gradle-based project. It provides two essential tasks: `BuildIl2CppTask`
+and `RefreshUnityAssetsTask`. This guide explains how to use these tasks effectively.
 
 ## Prerequisites
 
@@ -33,7 +35,8 @@ To get started, add the Unity Integration Plugin to your `build.gradle` file:
 
 ### Purpose
 
-The `BuildIl2CppTask` automates the compilation and building of Il2Cpp for Unity integration. It enhances the efficiency of your development workflow by handling complex build processes.
+The `BuildIl2CppTask` automates the compilation and building of Il2Cpp for Unity integration. It
+enhances the efficiency of your development workflow by handling complex build processes.
 
 ### Configuration
 
@@ -81,7 +84,8 @@ To use `BuildIl2CppTask`, follow these steps:
 ./gradlew buildIl2Cpp
 ```
 
-Here's a Kotlin code snippet for your `build.gradle` file that demonstrates the configuration and usage:
+Here's a Kotlin code snippet for your `build.gradle` file that demonstrates the configuration and
+usage:
 
 === "Kotlin"
 
@@ -104,15 +108,16 @@ Here's a Kotlin code snippet for your `build.gradle` file that demonstrates the 
     }
     ```
 
-### Using `UnityAssetSyncTask`
+## Using `RefreshUnityAssetsTask`
 
 ### Purpose
 
-The `UnityAssetSyncTask` streamlines the synchronization of Unity exported assets with your project. It prepares the project for Unity integration by copying essential folders.
+The `RefreshUnityAssetsTask` streamlines the synchronization and updating of Unity exported assets
+with your project. It prepares the project for Unity integration by updating essential folders.
 
 ### Configuration
 
-To use `UnityAssetSyncTask`, follow these steps:
+To use `RefreshUnityAssetsTask`, follow these steps:
 
 1. Configure Unity options in your `build.gradle` file (if not already done).
 
@@ -121,31 +126,32 @@ To use `UnityAssetSyncTask`, follow these steps:
 === "Groovy"
 
     ```groovy title="build.gradle"
-    createUnityAssetSyncTask(unityOptions)
+    createRefreshUnityAssetsTask(unityOptions)
     ```
 
 === "Kotlin"
 
     ```kotlin title="build.gradle.kts"
-    createUnityAssetSyncTask(unityOptions)
+    createRefreshUnityAssetsTask(unityOptions)
     ```
 
 3. Execute the task:
 
 ```shell
-./gradlew syncUnityAssets
+./gradlew refreshUnityAssets
 ```
 
-Here's a Kotlin code snippet for your `build.gradle` file that demonstrates the configuration and usage:
+Here's a Kotlin code snippet for your `build.gradle` file that demonstrates the configuration and
+usage:
 
 === "Kotlin"
 
     ```kotlin title="build.gradle.kts"
-    // Create and set up the UnityAssetSyncTask
-    createUnityAssetSyncTask(unityOptions)
+    // Create and set up the RefreshUnityAssetsTask
+    createRefreshUnityAssetsTask(unityOptions)
 
-    // Execute the UnityAssetSyncTask
-    tasks.named("syncUnityAssets").configure {
+    // Execute the RefreshUnityAssetsTask
+    tasks.named("refreshUnityAssets").configure {
         // Add any additional configuration or dependencies here if needed
         // For example:
         // dependsOn("anotherTask")
@@ -154,11 +160,13 @@ Here's a Kotlin code snippet for your `build.gradle` file that demonstrates the 
 
 ## Conclusion
 
-With the Unity Integration Plugin, you can seamlessly integrate Unity projects into your Gradle-based project, enhancing the development process and ensuring consistency. If you encounter any issues or have feature requests, please don't hesitate to contribute or reach out for support.
+With the Unity Integration Plugin, you can seamlessly integrate Unity projects into your
+Gradle-based project, enhancing the development process and ensuring consistency. If you encounter
+any issues or have feature requests, please don't hesitate to contribute or reach out for support.
 
 ## Quick References
 
 1. [Installation](#installation)
 2. [Using `BuildIl2CppTask`](#using-buildil2cpptask)
-3. [Using `UnityAssetSyncTask`](#using-unityassetsynctask)
+3. [Using `RefreshUnityAssetsTask`](#using-refreshunityassetstask)
 4. [Conclusion](#conclusion)

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -39,17 +39,22 @@ public final class dev/teogor/drifter/plugin/FolderDeletionException : java/lang
 public abstract interface annotation class dev/teogor/drifter/plugin/InternalDrifterApi : java/lang/annotation/Annotation {
 }
 
-public class dev/teogor/drifter/plugin/UnityAssetSyncTask : org/gradle/api/DefaultTask {
+public class dev/teogor/drifter/plugin/RefreshUnityAssetsTask : org/gradle/api/DefaultTask {
+	public static final field Companion Ldev/teogor/drifter/plugin/RefreshUnityAssetsTask$Companion;
+	public static final field TASK_NAME Ljava/lang/String;
 	public fun <init> ()V
-	public final fun importContent ()V
+	public final fun executeTask ()V
 	public final fun setUnityOptions (Ldev/teogor/drifter/plugin/models/UnityOptions;)V
 }
 
-public final class dev/teogor/drifter/plugin/UnityAssetSyncTaskKt {
-	public static final fun createUnityAssetSyncTask (Lorg/gradle/api/Project;Ldev/teogor/drifter/plugin/models/UnityOptions;)V
+public final class dev/teogor/drifter/plugin/RefreshUnityAssetsTask$Companion {
 }
 
-public final class dev/teogor/drifter/plugin/UnityAssetSyncTaskKt$inlined$sam$i$org_gradle_api_Action$0 : org/gradle/api/Action {
+public final class dev/teogor/drifter/plugin/RefreshUnityAssetsTaskKt {
+	public static final fun createRefreshUnityAssetsTask (Lorg/gradle/api/Project;Ldev/teogor/drifter/plugin/models/UnityOptions;)V
+}
+
+public final class dev/teogor/drifter/plugin/RefreshUnityAssetsTaskKt$inlined$sam$i$org_gradle_api_Action$0 : org/gradle/api/Action {
 	public fun <init> (Lkotlin/jvm/functions/Function1;)V
 	public final synthetic fun execute (Ljava/lang/Object;)V
 }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/BuildIl2CppTask.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/BuildIl2CppTask.kt
@@ -225,7 +225,7 @@ fun Project.createBuildIl2CppTask(
   unityOptions: UnityOptions,
 ) {
   tasks.register<BuildIl2CppTask>("buildIl2Cpp") {
-    dependsOn("syncUnityAssets")
+    dependsOn(RefreshUnityAssetsTask.TASK_NAME)
     setUnityOptions(unityOptions)
   }
 }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/UnityOptions.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/UnityOptions.kt
@@ -40,7 +40,7 @@ fun Project.unityOptions(
     unityOptions = unityOptions,
   )
 
-  createUnityAssetSyncTask(
+  createRefreshUnityAssetsTask(
     unityOptions = unityOptions,
   )
 


### PR DESCRIPTION
## Overview

This pull request introduces a significant refactor of the existing `UnityAssetSyncTask` class, renaming it to `RefreshUnityAssetsTask` to better reflect its purpose and functionality. The changes include updates to the task's description, method names, and the addition of a companion object for task name management. 

### Summary of Changes:

- **Renamed Class and Methods:**
  - The class `UnityAssetSyncTask` has been renamed to `RefreshUnityAssetsTask` to better describe its functionality of refreshing and updating Unity assets.
  - Updated method names and task descriptions accordingly.

- **Updated Documentation:**
  - Revised class-level and method-level comments to match the new class name and task functionality.
  - Added a `TASK_NAME` constant in the companion object for consistent task name management.

- **Exception Handling:**
  - Adjusted exception handling messages and documentation to align with the new class name and updated methods.

- **Task Registration:**
  - Updated the task registration method to reflect the new task class name and constant for task identification.

### Detailed Changes:

- **Class Renaming:**
  - Changed `UnityAssetSyncTask` to `RefreshUnityAssetsTask`.
  - Updated the `@see` references in the comments to use the new class name.

- **Method Updates:**
  - Renamed `importContent` to `executeTask` for clarity on the task's purpose.
  - Updated task description and method comments to reflect the new naming.

- **Documentation Enhancements:**
  - Improved inline documentation for better clarity and alignment with the updated class and method names.
  - Added a companion object with a `TASK_NAME` constant for easier task identification.
