### PR TITLE
Refactor BuildIl2CppTask to UnityNativeBuildTask and Add Initialization Check

### DIFF
--- a/docs/plugin-usage-guide.md
+++ b/docs/plugin-usage-guide.md
@@ -3,7 +3,7 @@
 ## Overview
 
 The Unity Integration Plugin simplifies the process of integrating Unity projects into your
-Gradle-based project. It provides two essential tasks: `BuildIl2CppTask`
+Gradle-based project. It provides two essential tasks: `UnityNativeBuildTask`
 and `RefreshUnityAssetsTask`. This guide explains how to use these tasks effectively.
 
 ## Prerequisites
@@ -31,37 +31,81 @@ To get started, add the Unity Integration Plugin to your `build.gradle` file:
     }
     ```
 
-## Using `BuildIl2CppTask`
+## Using `UnityNativeBuildTask`
 
 ### Purpose
 
-The `BuildIl2CppTask` automates the compilation and building of Il2Cpp for Unity integration. It
-enhances the efficiency of your development workflow by handling complex build processes.
+The `UnityNativeBuildTask` compiles and builds native code for Unity integration, managing
+architecture-specific binaries and output directories. It enhances the efficiency of your
+development workflow by automating the complex build processes required for Unity native code.
 
 ### Configuration
 
-To use `BuildIl2CppTask`, follow these steps:
+To use `UnityNativeBuildTask`, follow these steps:
 
 1. Configure Unity options in your `build.gradle` file:
 
 === "Groovy"
 
     ```groovy title="build.gradle"
-    unityOptions {
-        exportFolder = 'path/to/unity/export/folder'
-        libraryName = 'YourUnityLibrary'
-        // Add more configuration options as needed
+    android {
+        namespace = "dev.teogor.drifter.demo.module.unity"
+
+        unityOptions {
+            splashMode = 0
+            splashEnable = true
+            buildId = "ea574d1a-3365-44b3-9676-33bceabcf351"
+            notchConfig = "portrait|landscape"
+            version = "2022.3.7f1"
+
+            ndkVersion = "23.1.7779620"
+            ndkPath = getSafeDrifterUnityPathNdk()
+
+            platforms = [
+               PlatformArch.Arm64,
+               PlatformArch.Armv7
+            ]
+            configuration = Configuration.Release
+            streamingAssets.addAll(unityStreamingAssetsList)
+
+            exportedProjectLocation = getSafeDrifterUnityPathExport()
+            libraryName = 'YourUnityLibrary'
+        }
     }
     ```
 
 === "Kotlin"
 
     ```kotlin title="build.gradle.kts"
-    val unityOptions = mapOf(
-        "exportFolder" to "path/to/unity/export/folder",
-        "libraryName" to "YourUnityLibrary"
-        // Add more configuration options as needed
-    )
+    val unityStreamingAssets: String? by project
+    val unityStreamingAssetsList: List<String> = unityStreamingAssets?.split(",") ?: emptyList()
+
+    android {
+        namespace = "dev.teogor.drifter.demo.module.unity"
+
+        unityOptions(
+            androidConfig = this,
+        ) {
+            splashMode = 0
+            splashEnable = true
+            buildId = "ea574d1a-3365-44b3-9676-33bceabcf351"
+            notchConfig = "portrait|landscape"
+            version = "2022.3.7f1"
+
+            ndkVersion = "23.1.7779620"
+            ndkPath = getSafeDrifterUnityPathNdk()
+
+            platforms = listOf(
+              PlatformArch.Arm64,
+              PlatformArch.Armv7
+            )
+            configuration = Configuration.Release
+            streamingAssets += unityStreamingAssetsList
+
+            exportedProjectLocation = getSafeDrifterUnityPathExport()
+            libraryName = "YourUnityLibrary"
+        }
+    }
     ```
 
 2. Create the task and set Unity options:
@@ -69,19 +113,19 @@ To use `BuildIl2CppTask`, follow these steps:
 === "Groovy"
 
     ```groovy title="build.gradle"
-    createBuildIl2CppTask(unityOptions)
+    createUnityNativeBuildTask(unityOptions)
     ```
 
 === "Kotlin"
 
     ```kotlin title="build.gradle.kts"
-    createBuildIl2CppTask(unityOptions)
+    createUnityNativeBuildTask(unityOptions)
     ```
 
 3. Execute the task:
 
 ```shell
-./gradlew buildIl2Cpp
+./gradlew unityNativeBuild
 ```
 
 Here's a Kotlin code snippet for your `build.gradle` file that demonstrates the configuration and
@@ -97,11 +141,11 @@ usage:
         // Add more configuration options as needed
     )
 
-    // Create and set up the BuildIl2CppTask
-    createBuildIl2CppTask(unityOptions)
+    // Create and set up the UnityNativeBuildTask
+    createUnityNativeBuildTask(unityOptions)
 
-    // Execute the BuildIl2CppTask
-    tasks.named("buildIl2Cpp").configure {
+    // Execute the UnityNativeBuildTask
+    tasks.named("unityNativeBuild").configure {
         // Add any additional configuration or dependencies here if needed
         // For example:
         // dependsOn("someOtherTask")
@@ -113,7 +157,8 @@ usage:
 ### Purpose
 
 The `RefreshUnityAssetsTask` streamlines the synchronization and updating of Unity exported assets
-with your project. It prepares the project for Unity integration by updating essential folders.
+with your project. It prepares the project for Unity integration by updating essential folders and
+removing outdated content.
 
 ### Configuration
 
@@ -167,6 +212,6 @@ any issues or have feature requests, please don't hesitate to contribute or reac
 ## Quick References
 
 1. [Installation](#installation)
-2. [Using `BuildIl2CppTask`](#using-buildil2cpptask)
+2. [Using `UnityNativeBuildTask`](#using-unitynativebuildtask)
 3. [Using `RefreshUnityAssetsTask`](#using-refreshunityassetstask)
 4. [Conclusion](#conclusion)

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -1,18 +1,3 @@
-public class dev/teogor/drifter/plugin/BuildIl2CppTask : org/gradle/api/DefaultTask {
-	public fun <init> ()V
-	public final fun buildIl2Cpp ()V
-	public final fun setUnityOptions (Ldev/teogor/drifter/plugin/models/UnityOptions;)V
-}
-
-public final class dev/teogor/drifter/plugin/BuildIl2CppTaskKt {
-	public static final fun createBuildIl2CppTask (Lorg/gradle/api/Project;Ldev/teogor/drifter/plugin/models/UnityOptions;)V
-}
-
-public final class dev/teogor/drifter/plugin/BuildIl2CppTaskKt$inlined$sam$i$org_gradle_api_Action$0 : org/gradle/api/Action {
-	public fun <init> (Lkotlin/jvm/functions/Function1;)V
-	public final synthetic fun execute (Ljava/lang/Object;)V
-}
-
 public final class dev/teogor/drifter/plugin/ContentCopyException : java/lang/RuntimeException {
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -67,12 +52,28 @@ public final class dev/teogor/drifter/plugin/UnityManifestPlaceholdersKt {
 	public static final fun applyUnityManifestPlaceholders (Lcom/android/build/api/dsl/CommonExtension;Ldev/teogor/drifter/plugin/models/UnityOptions;)V
 }
 
-public final class dev/teogor/drifter/plugin/UnityOptionsKt {
-	public static final fun unityOptions (Lorg/gradle/api/Project;Lcom/android/build/api/dsl/CommonExtension;Lkotlin/jvm/functions/Function1;)V
+public class dev/teogor/drifter/plugin/UnityNativeBuildTask : org/gradle/api/DefaultTask {
+	public static final field Companion Ldev/teogor/drifter/plugin/UnityNativeBuildTask$Companion;
+	public static final field TASK_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public final fun buildUnityNative ()V
+	public final fun setUnityOptions (Ldev/teogor/drifter/plugin/models/UnityOptions;)V
 }
 
-public final class dev/teogor/drifter/plugin/UnityOptionsNotInitializedException : java/lang/RuntimeException {
-	public fun <init> ()V
+public final class dev/teogor/drifter/plugin/UnityNativeBuildTask$Companion {
+}
+
+public final class dev/teogor/drifter/plugin/UnityNativeBuildTaskKt {
+	public static final fun createUnityNativeBuildTask (Lorg/gradle/api/Project;Ldev/teogor/drifter/plugin/models/UnityOptions;)V
+}
+
+public final class dev/teogor/drifter/plugin/UnityNativeBuildTaskKt$inlined$sam$i$org_gradle_api_Action$0 : org/gradle/api/Action {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final synthetic fun execute (Ljava/lang/Object;)V
+}
+
+public final class dev/teogor/drifter/plugin/UnityOptionsKt {
+	public static final fun unityOptions (Lorg/gradle/api/Project;Lcom/android/build/api/dsl/CommonExtension;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class dev/teogor/drifter/plugin/models/Configuration : java/lang/Enum {
@@ -152,5 +153,9 @@ public final class dev/teogor/drifter/plugin/models/UnityOptions {
 	public final fun setStreamingAssets (Ljava/util/List;)V
 	public final fun setVersion (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/drifter/plugin/utils/error/UnityOptionsNotInitializedException : java/lang/RuntimeException {
+	public fun <init> ()V
 }
 

--- a/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/RefreshUnityAssetsTask.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/RefreshUnityAssetsTask.kt
@@ -17,6 +17,7 @@
 package dev.teogor.drifter.plugin
 
 import dev.teogor.drifter.plugin.models.UnityOptions
+import dev.teogor.drifter.plugin.utils.error.UnityOptionsNotInitializedException
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
@@ -178,19 +179,6 @@ open class RefreshUnityAssetsTask : DefaultTask() {
     const val TASK_NAME = "refreshUnityAssets"
   }
 }
-
-/**
- * Exception thrown when attempting to use the task before initializing UnityOptions.
- *
- * @see [RefreshUnityAssetsTask.checkInitialized]
- */
-class UnityOptionsNotInitializedException : RuntimeException(
-  """
-  |UnityOptions is not initialized. Please call setUnityOptions() before using this task.
-  |
-  |To report this problem, file an issue on GitHub: https://github.com/teogor/drifter/issues
-  """.trimMargin(),
-)
 
 /**
  * Exception thrown when folder deletion fails during the task execution.

--- a/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/UnityBuildTask.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/UnityBuildTask.kt
@@ -25,7 +25,7 @@ fun Project.unityBuildTask(
   commonExtension: CommonExtension<*, *, *, *, *, *>,
   unityOptions: UnityOptions,
 ) {
-  val buildIl2CppTask = project.tasks.getByName("buildIl2Cpp")
+  val unityNativeBuildTask = project.tasks.getByName(UnityNativeBuildTask.TASK_NAME)
 
   if (unityOptions.ndkPath.isEmpty()) {
     unityOptions.ndkPath = drifterUnityPathNdk ?: ""
@@ -59,11 +59,11 @@ fun Project.unityBuildTask(
     afterEvaluate {
       if (project(path).tasks.findByName("mergeDebugJniLibFolders") != null) {
         project(path).tasks.named("mergeDebugJniLibFolders").get()
-          .dependsOn(buildIl2CppTask)
+          .dependsOn(unityNativeBuildTask)
       }
       if (project(path).tasks.findByName("mergeReleaseJniLibFolders") != null) {
         project(path).tasks.named("mergeReleaseJniLibFolders").get()
-          .dependsOn(buildIl2CppTask)
+          .dependsOn(unityNativeBuildTask)
       }
     }
 

--- a/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/UnityNativeBuildTask.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/UnityNativeBuildTask.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2023 teogor (Teodor Grigor)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@ import com.android.build.api.dsl.SdkComponents
 import com.android.build.api.variant.AndroidComponents
 import dev.teogor.drifter.plugin.models.PlatformArch
 import dev.teogor.drifter.plugin.models.UnityOptions
+import dev.teogor.drifter.plugin.utils.error.UnityOptionsNotInitializedException
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.CopySpec
@@ -39,8 +40,7 @@ import org.gradle.process.ExecSpec
  * @see [createUnityNativeBuildTask]
  */
 open class UnityNativeBuildTask : DefaultTask() {
-
-  private var unityOptions: UnityOptions? = null
+  private lateinit var unityOptions: UnityOptions
 
   private val workingDir: String by lazy {
     project.projectDir.toString().replace("\\\\", "/")
@@ -61,13 +61,10 @@ open class UnityNativeBuildTask : DefaultTask() {
    */
   @TaskAction
   fun buildUnityNative() {
+    checkInitialized()
+
     try {
-      if (unityOptions == null) {
-        throw RuntimeException(
-          "An error occurred when trying to access 'unityOptions.' Please help us by reporting this issue at https://github.com/teogor/drifter/issues/new.",
-        )
-      }
-      val options = unityOptions!!
+      val options = unityOptions
 
       val configuration = options.configuration.value
       val staticLibraries = emptyArray<String>()
@@ -194,6 +191,17 @@ open class UnityNativeBuildTask : DefaultTask() {
     executableExtension: String,
   ): String {
     return "$workingDir/src/main/Il2CppOutputProject/IL2CPP/build/deploy/il2cpp$executableExtension"
+  }
+
+  /**
+   * Checks if UnityOptions has been initialized. Throws an exception if it has not.
+   *
+   * @throws UnityOptionsNotInitializedException if UnityOptions is not initialized.
+   */
+  private fun checkInitialized() {
+    if (!::unityOptions.isInitialized) {
+      throw UnityOptionsNotInitializedException()
+    }
   }
 
   companion object {

--- a/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/UnityNativeBuildTask.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/UnityNativeBuildTask.kt
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2023 teogor (Teodor Grigor)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,16 @@ import org.gradle.api.tasks.TaskExecutionException
 import org.gradle.kotlin.dsl.register
 import org.gradle.process.ExecSpec
 
-open class BuildIl2CppTask : DefaultTask() {
+/**
+ * A Gradle task for building native code for Unity integration.
+ *
+ * This task performs the following actions:
+ * - Executes the native compiler with the specified configuration and architecture.
+ * - Manages the output of the compilation process, including copying and deleting files.
+ *
+ * @see [createUnityNativeBuildTask]
+ */
+open class UnityNativeBuildTask : DefaultTask() {
 
   private var unityOptions: UnityOptions? = null
 
@@ -39,14 +48,21 @@ open class BuildIl2CppTask : DefaultTask() {
 
   init {
     group = "dev.teogor.drifter"
-    description = "Compile and build Il2Cpp for Unity integration"
+    description = "Compiles and builds native code for integrating with Unity, targeting multiple architectures."
   }
 
+  /**
+   * Executes the native build process.
+   *
+   * This method orchestrates the build process by calling individual methods
+   * for building and managing native code.
+   *
+   * @throws TaskExecutionException if an error occurs during the task execution.
+   */
   @TaskAction
-  fun buildIl2Cpp() {
+  fun buildUnityNative() {
     try {
       if (unityOptions == null) {
-        // TODO: Consider making 'unityOptions' a global variable to handle null scenarios.
         throw RuntimeException(
           "An error occurred when trying to access 'unityOptions.' Please help us by reporting this issue at https://github.com/teogor/drifter/issues/new.",
         )
@@ -60,7 +76,7 @@ open class BuildIl2CppTask : DefaultTask() {
       val sdkComponents = android.sdkComponents
 
       options.platforms.forEach { architecture ->
-        project.buildIl2Cpp(
+        project.buildUnityNative(
           workingDir = workingDir,
           configuration = configuration,
           architecture = architecture,
@@ -73,11 +89,26 @@ open class BuildIl2CppTask : DefaultTask() {
     }
   }
 
+  /**
+   * Sets the UnityOptions for this task.
+   *
+   * @param unityOptions The UnityOptions to be used by the task.
+   */
   fun setUnityOptions(unityOptions: UnityOptions) {
     this.unityOptions = unityOptions
   }
 
-  private fun Project.buildIl2Cpp(
+  /**
+   * Builds native code for Unity integration.
+   *
+   * @receiver The Gradle Project instance.
+   * @param workingDir The root directory of the native project.
+   * @param configuration The build configuration (e.g., Debug, Release).
+   * @param architecture The target architecture for the build.
+   * @param staticLibraries An array of additional static libraries.
+   * @param sdkComponents The SDK components required for the build.
+   */
+  private fun Project.buildUnityNative(
     workingDir: String,
     configuration: String,
     architecture: PlatformArch,
@@ -119,14 +150,11 @@ open class BuildIl2CppTask : DefaultTask() {
       commandLineArgs.replaceAll { it.replace("\"", "\\\"") }
     }
 
-    // Create a copy task to move the file to the desired location
-    tasks.create("copyLibil2cpp$abi") {
+    tasks.create("copyLibNative$abi") {
       val execSpec = exec {
-        // Explicitly cast to ExecSpec to address lambda capture limitations and
-        // guarantee type safety for the extension method call.
         @Suppress("USELESS_CAST", "KotlinRedundantDiagnosticSuppress")
-        (this as ExecSpec).configureIl2CppExec(
-          executablePath = getIl2CppExecutablePath(
+        (this as ExecSpec).configureNativeBuildExec(
+          executablePath = getNativeExecutablePath(
             workingDir,
             executableExtension,
           ),
@@ -137,20 +165,16 @@ open class BuildIl2CppTask : DefaultTask() {
       execSpec.assertNormalExitValue()
 
       copy {
-        // Explicitly cast to CopySpec to address lambda capture limitations and
-        // guarantee type safety for the extension method call.
         @Suppress("USELESS_CAST", "KotlinRedundantDiagnosticSuppress")
-        (this as CopySpec).copyIl2CppSymbols(
+        (this as CopySpec).copyNativeSymbols(
           workingDir = workingDir,
           abi = abi,
         )
       }
 
       delete {
-        // Explicitly cast to DeleteSpec to address lambda capture limitations and
-        // guarantee type safety for the extension method call.
         @Suppress("USELESS_CAST", "KotlinRedundantDiagnosticSuppress")
-        (this as DeleteSpec).deleteUnnecessaryIl2CppFiles(
+        (this as DeleteSpec).deleteUnnecessaryNativeFiles(
           workingDir = workingDir,
           abi = abi,
         )
@@ -158,23 +182,42 @@ open class BuildIl2CppTask : DefaultTask() {
     }
   }
 
-  private fun getIl2CppExecutablePath(
+  /**
+   * Gets the path to the native executable.
+   *
+   * @param workingDir The root directory of the native project.
+   * @param executableExtension The extension of the executable (e.g., ".exe" for Windows).
+   * @return The path to the native executable.
+   */
+  private fun getNativeExecutablePath(
     workingDir: String,
     executableExtension: String,
   ): String {
     return "$workingDir/src/main/Il2CppOutputProject/IL2CPP/build/deploy/il2cpp$executableExtension"
   }
+
+  companion object {
+    /**
+     * The name of the Gradle task for building native code for Unity integration.
+     *
+     * This constant is used to identify the task in Gradle's task registry and can be used
+     * when registering or configuring the task in build scripts or other Gradle-related code.
+     *
+     * @see [createUnityNativeBuildTask]
+     */
+    const val TASK_NAME = "unityNativeBuild"
+  }
 }
 
 /**
- * Configures an [ExecSpec] for executing the Il2Cpp compiler.
+ * Configures an [ExecSpec] for executing the native compiler.
  *
  * @receiver The [ExecSpec] to be configured.
- * @param executablePath The path to the Il2Cpp executable.
- * @param commandLineArgs The command-line arguments to pass to the Il2Cpp executable.
+ * @param executablePath The path to the native executable.
+ * @param commandLineArgs The command-line arguments to pass to the native executable.
  * @param sdkDirectory The path to the Android SDK root directory.
  */
-private fun ExecSpec.configureIl2CppExec(
+private fun ExecSpec.configureNativeBuildExec(
   executablePath: String,
   commandLineArgs: MutableList<String>,
   sdkDirectory: String,
@@ -185,13 +228,13 @@ private fun ExecSpec.configureIl2CppExec(
 }
 
 /**
- * Copies Il2Cpp symbol files to the appropriate destination.
+ * Copies native symbol files to the appropriate destination.
  *
  * @receiver The [CopySpec] to be configured.
- * @param workingDir The root directory of the Il2Cpp project.
+ * @param workingDir The root directory of the native project.
  * @param abi The target ABI for the symbol files.
  */
-private fun CopySpec.copyIl2CppSymbols(
+private fun CopySpec.copyNativeSymbols(
   workingDir: String,
   abi: String,
 ) {
@@ -201,13 +244,13 @@ private fun CopySpec.copyIl2CppSymbols(
 }
 
 /**
- * Deletes unnecessary Il2Cpp files from the jniLibs directory.
+ * Deletes unnecessary native files from the jniLibs directory.
  *
  * @receiver The [DeleteSpec] to be configured.
- * @param workingDir The root directory of the Il2Cpp project.
+ * @param workingDir The root directory of the native project.
  * @param abi The target ABI for the files to be deleted.
  */
-private fun DeleteSpec.deleteUnnecessaryIl2CppFiles(
+private fun DeleteSpec.deleteUnnecessaryNativeFiles(
   workingDir: String,
   abi: String,
 ) {
@@ -216,15 +259,16 @@ private fun DeleteSpec.deleteUnnecessaryIl2CppFiles(
 }
 
 /**
- * Creates a Gradle task for building Il2Cpp.
+ * Creates and registers a [UnityNativeBuildTask] with the given [unityOptions].
  *
- * @receiver The Gradle Project instance.
- * @param unityOptions The configuration options for Unity integration.
+ * @param unityOptions The UnityOptions to be used by the task.
+ *
+ * @see [UnityNativeBuildTask]
  */
-fun Project.createBuildIl2CppTask(
+fun Project.createUnityNativeBuildTask(
   unityOptions: UnityOptions,
 ) {
-  tasks.register<BuildIl2CppTask>("buildIl2Cpp") {
+  tasks.register<UnityNativeBuildTask>(UnityNativeBuildTask.TASK_NAME) {
     dependsOn(RefreshUnityAssetsTask.TASK_NAME)
     setUnityOptions(unityOptions)
   }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/UnityOptions.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/UnityOptions.kt
@@ -36,7 +36,7 @@ fun Project.unityOptions(
     unityOptions = unityOptions,
   )
 
-  createBuildIl2CppTask(
+  createUnityNativeBuildTask(
     unityOptions = unityOptions,
   )
 

--- a/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/utils/error/UnityOptionsNotInitializedException.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/drifter/plugin/utils/error/UnityOptionsNotInitializedException.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.drifter.plugin.utils.error
+
+import dev.teogor.drifter.plugin.RefreshUnityAssetsTask
+
+/**
+ * Exception thrown when attempting to use the task before initializing UnityOptions.
+ *
+ * @see [RefreshUnityAssetsTask.checkInitialized]
+ */
+class UnityOptionsNotInitializedException : RuntimeException(
+  """
+  |UnityOptions is not initialized. Please call setUnityOptions() before using this task.
+  |
+  |To report this problem, file an issue on GitHub: https://github.com/teogor/drifter/issues
+  """.trimMargin(),
+)


### PR DESCRIPTION
### Overview

This pull request introduces two main updates to the Gradle plugin:

1. **Refactor and Rename Task Class**: 
   - The `BuildIl2CppTask` class has been refactored and renamed to `UnityNativeBuildTask`. 
   - The new class name better reflects its purpose for building native code for Unity integration. 
   - Associated methods and configurations have been updated accordingly, including task names and file handling.

2. **Add Initialization Check for UnityOptions**:
   - Added a new exception class, `UnityOptionsNotInitializedException`, which is thrown if `UnityOptions` is accessed before being properly initialized.
   - Implemented a `checkInitialized()` method to verify that `UnityOptions` is set before proceeding with tasks that depend on it.

### Documentation

- Updated documentation to reflect changes in task names and error handling.
- Added comments for new methods and classes to provide context and usage instructions.
